### PR TITLE
bots and explosives added to each BP

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -257,6 +257,10 @@ function generateSubScreenFromBPItems(player, bpItems)
 
         itemTotals = {}
         itemBuffers = {}
+
+        bpItems["construction-robot"] = 50
+        bpItems["logistic-robot"] = 100
+        bpItems["cliff-explosives"] = 60
         
         for k, v in pairs(bpItems) do
             local sub_content_flow = sub_scroll_pane.add{type="flow", name="bat_controls_flow_"..k, direction="horizontal", style="bat_content_flow"}


### PR DESCRIPTION
Change was simpler than I originally thought it would be. I did not end up making any UI changes to accommodate it. By placing the items in the table last, the will automatically show at the end of the list thanks to LUA mechanics. In the future, settings should be created to control if these items are added automatically.